### PR TITLE
Add lambda request type

### DIFF
--- a/lambda/handlers/entry.ts
+++ b/lambda/handlers/entry.ts
@@ -1,7 +1,7 @@
-import { LambdaResponse } from '../types';
+import { LambdaRequest, LambdaResponse } from '../types';
 
 exports.handler = async function (
-    event: any,
+    event: LambdaRequest,
     context: any
 ): Promise<LambdaResponse> {
     console.log('EVENT: \n' + JSON.stringify(event, null, 2));

--- a/lambda/types.ts
+++ b/lambda/types.ts
@@ -1,3 +1,23 @@
+export interface LambdaRequest {
+    resource: string;
+    path: string;
+    httpMethod: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+    headers: {
+        [key: string]: string;
+    } | null;
+    multiValueHeaders: {
+        [key: string]: string[];
+    } | null;
+    queryStringParameters: {
+        [key: string]: string;
+    } | null;
+    multiValueQueryStringParameters: {
+        [key: string]: string[];
+    } | null;
+    body: string | null;
+    isBase64Encoded: boolean;
+}
+
 export interface LambdaResponse {
     isBase64Encoded?: boolean;
     statusCode: number;

--- a/lambda/types.ts
+++ b/lambda/types.ts
@@ -16,6 +16,7 @@ export interface LambdaRequest {
     } | null;
     body: string | null;
     isBase64Encoded: boolean;
+    [key: string]: any;
 }
 
 export interface LambdaResponse {


### PR DESCRIPTION
APIGW から Lambda 関数に渡される event の型も定義しました。

全パラメータを定義するとnullable や undefined をどう許容していいかの確認が大変なので、使う予定がありそうなパラメータの定義に絞ってあります。
https://docs.aws.amazon.com/ja_jp/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format