### PR TITLE
Return error response if `event.body` is empty

### DIFF
--- a/lambda/handlers/entry.ts
+++ b/lambda/handlers/entry.ts
@@ -7,7 +7,7 @@ exports.handler = async function (
     console.log('EVENT: \n' + JSON.stringify(event, null, 2));
 
     // return error response if request body is empty
-    if (event.body == null) {
+    if (event.body === null) {
         const response: LambdaResponse = {
             statusCode: 400,
             body: 'Bad Request',

--- a/lambda/handlers/entry.ts
+++ b/lambda/handlers/entry.ts
@@ -5,19 +5,27 @@ exports.handler = async function (
     context: any
 ): Promise<LambdaResponse> {
     console.log('EVENT: \n' + JSON.stringify(event, null, 2));
+
+    // return error response if request body is empty
+    if (event.body == null) {
+        const response: LambdaResponse = {
+            statusCode: 400,
+            body: 'Bad Request',
+        };
+        return response;
+    }
+
     let lambdaEvent;
-    if (event.body) {
-        try {
-            lambdaEvent = JSON.parse(event.body);
-        } catch (err) {
-            // Request body is not JSON syntax
-            console.error(err);
-            const response: LambdaResponse = {
-                statusCode: 400,
-                body: 'Bad Request',
-            };
-            return response;
-        }
+    try {
+        lambdaEvent = JSON.parse(event.body);
+    } catch (err) {
+        // Request body is not JSON syntax
+        console.error(err);
+        const response: LambdaResponse = {
+            statusCode: 400,
+            body: 'Bad Request',
+        };
+        return response;
     }
 
     // Handle challenge request


### PR DESCRIPTION
リクエストボディが空のPOSTリクエストが来た時、`event.body` は `null` になる。

```json
{
    "resource": "/",
    "path": "/",
    "httpMethod": "POST",
...
    },
    "body": null,
    "isBase64Encoded": false
}
```

この時現状のLambda関数のコードだと、`lambdaEvent` が `undefined` になるのでエラーになります。

https://github.com/ykhr53/new-bmo/blob/86f5ac99a07e3cbb46f651e2dbeb906551d01736/lambda/handlers/entry.ts#L8-L24

```json
{
    "errorType": "TypeError",
    "errorMessage": "Cannot read property 'challenge' of undefined",
    "stack": [
        "TypeError: Cannot read property 'challenge' of undefined",
        "    at Runtime.exports.handler (/var/task/index.js:17:33)",
        "    at Runtime.handleOnce (/var/runtime/Runtime.js:66:25)"
    ]
}
```

`event.body` が `null` のとき、想定されないリクエストだと思われるので、早期 `return` でエラーレスポンスを返すようにしました。
