### PR TITLE
Separate reactions of the bot from lambda handler

### DIFF
--- a/lambda/handlers/entry.ts
+++ b/lambda/handlers/entry.ts
@@ -115,6 +115,8 @@ async function behaiveReaction(
             reply = await ddb.search(query);
             break;
     }
+
+    // Post a reply message to slack if it is not empty
     if (reply) {
         try {
             await slack.chat.postMessage({

--- a/lambda/handlers/entry.ts
+++ b/lambda/handlers/entry.ts
@@ -75,9 +75,9 @@ async function behaiveReaction(
     incomingMessage: SlackMessage,
     slack: WebClient
 ) {
-    const commentType = searchRegex(incomingMessage);
+    const reactionType = findReactionType(incomingMessage);
     let reply = '';
-    switch (commentType) {
+    switch (reactionType) {
         case 'vote':
             const vd = parseVote(incomingMessage.text);
             reply = await ddb.vote(vd);
@@ -150,7 +150,7 @@ function isBMO(message: SlackMessage, appuname: string): boolean {
     return message.user == appuname;
 }
 
-function searchRegex(message: SlackMessage): string {
+function findReactionType(message: SlackMessage): string {
     const text = message.text;
     for (let key in BMO_REGEX) {
         if (text.match(BMO_REGEX[key]) != null) {


### PR DESCRIPTION
BMOの具体的な振る舞い(Slackへの投稿など) を Lambda のハンドラから切り出しました。
切り出した behaveReaction 関数もこれから少し責務を分けていったりしたいなと思いその下準備的な変更です。
動作は変わらないはず。