### PR TITLE
Fix to do reactions when other users post messages

### DIFF
--- a/lambda/handlers/entry.ts
+++ b/lambda/handlers/entry.ts
@@ -61,7 +61,7 @@ exports.handler = async function (
     const slack = new WebClient(SLACK_TOKEN);
     const message: SlackMessage = getMessage(lambdaEvent);
 
-    if (!isBMO(message, APP_UNAME)) {
+    if (isBMO(message, APP_UNAME)) {
         // Return immediately if the message is posted by BMO
         return HTTP_200;
     }


### PR DESCRIPTION
BMO以外が発言したときに何も反応しなくなってしまった問題の修正。

以前の変更時に、「BMOが発言したとき」という条件分岐を「BMO以外が発言したとき」に書き直そうとしてやめたのが残ってしまっていたのを戻しました。