### PR TITLE
Add await in calling reactions

### DIFF
--- a/lambda/handlers/entry.ts
+++ b/lambda/handlers/entry.ts
@@ -69,12 +69,12 @@ async function behaveReactions(
     incomingMessage: SlackMessage,
     reactionContext: ReactionContext
 ) {
-    behaviors.forEach((behavior) => {
+    for (const behavior of behaviors) {
         if (incomingMessage.text.match(behavior.triggerPattern) != null) {
             console.log(`triggered reaction "${behavior.type}"`);
-            behavior.reaction(incomingMessage, reactionContext);
+            await behavior.reaction(incomingMessage, reactionContext);
         }
-    });
+    }
 }
 
 function getMessage(lambdaEvent: { [key: string]: any }): SlackMessage {


### PR DESCRIPTION
reaction を呼び出すときにawait がないために、Lambda関数が実行を待たずに終了してしまっていた。
await を追加して同期的な処理になるようにしました。